### PR TITLE
Encriptar contraseña con SHA256

### DIFF
--- a/password.py
+++ b/password.py
@@ -1,0 +1,15 @@
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+import base64
+
+
+# https://cryptography.io/en/latest/fernet/#using-passwords-with-fernet
+def derive_key(password: str) -> bytes:
+    salt = b'\xd3\x96\xf7\xa1\x93vO\x02P4\xf6\xd6ka\x80\x84'
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=480000,
+    )
+    return base64.urlsafe_b64encode(kdf.derive(bytes(password, 'utf-8')))


### PR DESCRIPTION
Usamos el método recomendado por cryptography para obtener una versión encriptada de la contraseña proporiconada por el usuario. En este caso el salt está predeterminado ya que no entra en los requisitos del proyecto.